### PR TITLE
Add MCP server configuration for Notion API integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "notionApi": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "OPENAPI_MCP_HEADERS=\"{\\\"Authorization\\\": \\\"Bearer $NOTION_TOKEN\\\", \\\"Notion-Version\\\": \\\"2022-06-28\\\"}\" npx -y @notionhq/notion-mcp-server"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Model Context Protocol (MCP) server configuration to enable integration with the Notion API.

## Key Changes
- Added `.mcp.json` configuration file that defines the `notionApi` MCP server
- Configured the server to use the official `@notionhq/notion-mcp-server` package
- Set up authentication headers with Notion API token and API version specification

## Implementation Details
The configuration uses the Notion MCP server with:
- Authorization via Bearer token from the `NOTION_TOKEN` environment variable
- Notion API version pinned to `2022-06-28` for compatibility
- Server launched via `npx` for easy dependency management without local installation

https://claude.ai/code/session_01Pdyprk9bQYaHiNcMX2ipnd