### PR TITLE
💄 スマホ表示時のヘッダー要素はみ出し・横スクロールを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 playwright/.auth/
+
+# playwright-skill (.claude/skills, .agents/skills) runtime temp files
+**/.temp-execution-*.js

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,23 +17,26 @@ export default async function Header() {
 
   return (
     <header className="bg-[#2d5a27] text-primary-foreground p-3 px-4">
-      <div className="max-w-6xl mx-auto flex items-center gap-3">
-        <div className="flex items-center gap-2">
+      <div className="max-w-6xl mx-auto flex items-center gap-1 sm:gap-3">
+        <div className="flex items-center gap-1 sm:gap-2 min-w-0">
           <Link
             href="/"
-            className="flex items-center gap-2 text-xl max-sm:text-lg font-medium whitespace-nowrap"
+            className="flex items-center gap-1 sm:gap-2 text-xl max-sm:text-base font-medium whitespace-nowrap"
           >
-            <PawPrint className="w-6 h-6" />
+            <PawPrint className="w-5 h-5 sm:w-6 sm:h-6 shrink-0" />
             猫と植物
-            <Leaf className="w-6 h-6" />
+            <Leaf className="w-5 h-5 sm:w-6 sm:h-6 shrink-0" />
           </Link>
           <span className="text-xs text-green-200 max-sm:hidden">Beta Version</span>
         </div>
         <HeaderNav />
         <div className="flex-1"></div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2 min-w-0">
           {!session || !user ? (
-            <Button className="bg-accent text-accent-foreground hover:bg-accent/90" asChild>
+            <Button
+              className="bg-accent text-accent-foreground hover:bg-accent/90 max-sm:px-3 max-sm:h-8 max-sm:text-xs"
+              asChild
+            >
               <Link href="/signin" className="text-accent-foreground">
                 ログイン
               </Link>
@@ -45,7 +48,7 @@ export default async function Header() {
                   <Camera className="w-6 h-6 text-green-500" />
                 </Link>
               </Button>
-              <Button variant="outline" className="hidden sm:flex mr-2" asChild>
+              <Button variant="outline" className="hidden sm:flex" asChild>
                 <Link href="/posts/new" className="text-accent-foreground">
                   <span className="flex items-center gap-2">
                     <Camera className="w-6 h-6 text-green-500" />

--- a/src/components/HeaderDropMenu.tsx
+++ b/src/components/HeaderDropMenu.tsx
@@ -85,7 +85,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
           <AvatarImage src={userImage || undefined} alt={userName || "User"} />
           <AvatarFallback>{userName.charAt(0) || "U"}</AvatarFallback>
         </Avatar>
-        <span className="text-sm max-sm:hidden">{userName}</span>
+        <span className="text-sm hidden md:inline-block truncate max-w-[8rem]">{userName}</span>
       </button>
       {isOpen && (
         <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg py-1 text-gray-700">

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -16,13 +16,13 @@ export default function HeaderNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex gap-1 ml-2">
+    <nav className="flex gap-0.5 sm:gap-1 ml-1 sm:ml-2">
       {NAV_ITEMS.map((item) => (
         <Link
           key={item.href}
           href={item.href}
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            "inline-flex items-center gap-1.5 rounded-md px-2 sm:px-2.5 py-1.5 text-sm font-medium whitespace-nowrap transition-colors",
             item.isActive(pathname) ? "bg-white/15" : "hover:bg-white/10",
           )}
         >


### PR DESCRIPTION
ロゴ/ナビ/ログインボタン・アバターの合計幅が狭い画面で縮小しきれず、
320px〜768px付近で横スクロールが発生していたのを、余白・アイコンサイズの
調整とユーザー名表示の切替幅見直しで解消。