### PR TITLE
✨ RLS構造テストを動的スキャン方式に変更し新規テーブルのRLS付け忘れを検知

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: 2.109.1
 
       - name: Prepare storage dirs for Supabase
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ npm run lint             # ESLint
 - Server ActionsはVitestを使用したユニットテスト
 - 重要なユーザーフローはPlaywright E2Eテストでカバー
 - E2Eテストには認証フローが含まれ、シードされたテストデータが必要
-- RLS・ストレージポリシーはpgTAPテスト（`supabase/tests/*.sql`、`supabase test db`で実行）で退行を検知。anonキーでPostgREST/Storageを直接叩かれても守れることを担保する。ポリシーを追加・変更するマイグレーションでは `01_rls_structure.sql` のポリシー一覧も更新する
+- RLS・ストレージポリシーはpgTAPテスト（`supabase/tests/*.sql`、`supabase test db`で実行）で退行を検知。anonキーでPostgREST/Storageを直接叩かれても守れることを担保する。テーブルを追加・削除・リネームするマイグレーションでは `01_rls_structure.sql` のテーブル一覧を、ポリシーを追加・変更するマイグレーションでは同ファイルのポリシー一覧を、それぞれ更新する
 
 ### ローカライゼーション
 アプリケーションは主に日本語で、日本語フォント（M_PLUS_Rounded_1c）を使用。コンテンツとメタデータは日本語中心。
@@ -80,7 +80,7 @@ npm run lint             # ESLint
 データベースは自動ユーザープロフィール作成とデータ整合性のためのトリガーを使用。トリガーのドキュメントは`/doc/supabase.md`を参照。
 
 ### データベース変更のルール
-**スキーマの正は `supabase/migrations/*.sql`（Supabaseマイグレーション）。** `prisma/schema.prisma` は `prisma db pull` で生成する Prisma Client 用のイントロスペクション成果物であり、手で編集しない。RLS・ストレージポリシー・トリガー・関数もすべてマイグレーションSQLに含める（Prisma Migrate は使用しない）。
+**スキーマの正は `supabase/migrations/*.sql`（Supabaseマイグレーション）。** `prisma/schema.prisma` は `prisma db pull` で生成する Prisma Client 用のイントロスペクション成果物であり、手で編集しない。RLS・ストレージポリシー・トリガー・関数もすべてマイグレーションSQLに含める（Prisma Migrate は使用しない）。新規テーブルを作成する際は、同じマイグレーション内で原則 `ENABLE ROW LEVEL SECURITY` を設定する（意図的に無効のままにする場合は理由をPRに明記する）。
 
 変更手順:
 1. マイグレーションを作成する

--- a/supabase/tests/01_rls_structure.sql
+++ b/supabase/tests/01_rls_structure.sql
@@ -1,31 +1,50 @@
 -- =============================================================
 -- RLS 構造テスト（ドリフト検知）
 --
--- ポリシーの一覧・対象コマンド・対象ロール・テーブル権限をカタログから
--- 検証し、マイグレーションによる意図しない変更（ポリシーの追加/削除/
--- 拡大、GRANT の復活）を検知する。
--- ポリシーを追加・変更するマイグレーションを書いたら、このファイルの
--- 一覧もセットで更新すること（それがこのテストの目的）。
+-- テーブル一覧・RLS有効化状態・ポリシーの一覧・対象コマンド・対象ロール・
+-- テーブル権限をカタログから検証し、マイグレーションによる意図しない変更
+-- （テーブルの追加/削除、RLS無効化、ポリシーの追加/削除/拡大、GRANT の
+-- 復活）を検知する。
+-- テーブルを追加・削除・リネームする、またはポリシーを追加・変更する
+-- マイグレーションを書いたら、このファイルの一覧もセットで更新すること
+-- （それがこのテストの目的）。
 --
 -- 実行: supabase test db（ローカルスタック起動中に）
 -- =============================================================
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(84);
+select plan(76);
 
 -- -------------------------------------------------------------
--- 1. public スキーマ: 全10テーブルで RLS が有効
+-- 1. public スキーマ: テーブル一覧が想定どおり、かつ全テーブルで RLS が有効
+--    (a) tables_are: テーブルの追加・削除・リネームを検知する。
+--        新しいテーブルができたらここに追加しない限り必ず失敗する
+--        ＝ 2〜5節のポリシー断言を追加し忘れる事故を防ぐ仕掛け。
+--    (b) is_empty: このリストに載っているかどうかを問わず、RLS が
+--        無効なテーブルを検知する（新規テーブルの設定漏れ／既存
+--        テーブルの無効化への退行のどちらも拾う）。
 -- -------------------------------------------------------------
-select ok((select relrowsecurity from pg_class where oid = 'public.plants'::regclass), 'RLS 有効: plants');
-select ok((select relrowsecurity from pg_class where oid = 'public.neko'::regclass), 'RLS 有効: neko');
-select ok((select relrowsecurity from pg_class where oid = 'public.users'::regclass), 'RLS 有効: users');
-select ok((select relrowsecurity from pg_class where oid = 'public.pets'::regclass), 'RLS 有効: pets');
-select ok((select relrowsecurity from pg_class where oid = 'public.posts'::regclass), 'RLS 有効: posts');
-select ok((select relrowsecurity from pg_class where oid = 'public.post_images'::regclass), 'RLS 有効: post_images');
-select ok((select relrowsecurity from pg_class where oid = 'public.post_likes'::regclass), 'RLS 有効: post_likes');
-select ok((select relrowsecurity from pg_class where oid = 'public.post_pets'::regclass), 'RLS 有効: post_pets');
-select ok((select relrowsecurity from pg_class where oid = 'public.post_plants'::regclass), 'RLS 有効: post_plants');
-select ok((select relrowsecurity from pg_class where oid = 'public.plant_identification_logs'::regclass), 'RLS 有効: plant_identification_logs');
+select tables_are(
+    'public',
+    array[
+        'plants', 'neko', 'users', 'pets', 'posts',
+        'post_images', 'post_likes', 'post_pets', 'post_plants',
+        'plant_identification_logs'
+    ],
+    'public スキーマのテーブルは想定の10個のみ'
+);
+
+select is_empty(
+    $$select relname from pg_class
+      where relnamespace = 'public'::regnamespace
+        and relkind = 'r'
+        and not relrowsecurity$$,
+    'public スキーマの全テーブルで RLS が有効（新規・既存を問わず検知）'
+);
+-- 注: relkind = 'r'（通常テーブル）のみ対象。パーティションテーブル（'p'）や
+-- ビューはこの2つの断言の対象外（tables_are 自体の仕様、かつ現状どちらも
+-- 存在しない）。将来パーティションテーブルを導入する場合はこのセクションの
+-- 見直しが必要。
 
 -- -------------------------------------------------------------
 -- 2. public スキーマ: ポリシーの完全一覧（過不足を検知）
@@ -96,7 +115,8 @@ select table_privs_are('public', 'plant_identification_logs', 'authenticated', a
 -- -------------------------------------------------------------
 -- 6. storage.objects: RLS + ポリシー完全一覧
 --    （storage の GRANT・トリガー・カラムは storage-api / CLI バージョン
---      管理下のため断言しない。リポジトリ管理下のポリシーのみ固定する）
+--      管理下のため断言しない。リポジトリ管理下のポリシーのみ固定する。
+--      同じ理由で storage スキーマのテーブル一覧そのものも断言しない）
 -- -------------------------------------------------------------
 select ok((select relrowsecurity from pg_class where oid = 'storage.objects'::regclass), 'RLS 有効: storage.objects');
 


### PR DESCRIPTION
## Summary
- `supabase/tests/01_rls_structure.sql` のRLSチェックを、テーブル名をハードコードした10個の`ok()`から、`tables_are()`（テーブル一覧の完全一致）+ `is_empty()`（RLS無効テーブルの検知）による動的スキャンに変更
- 新規テーブルを追加してRLSを付け忘れても、テーブル一覧のずれ・RLS無効の両方をCIが自動検知するようになった
- `CLAUDE.md` に「新規テーブル作成時は原則RLSを有効にする」運用ルールと、テスト側のテーブル一覧更新に関する記述を追記

#57 の「新規テーブル作成時にRLSをデフォルトで有効にする運用ルールがある」を、文書化だけでなくテストによる強制まで含めて対応するもの。

## Test plan
- [x] ローカルで `supabase db reset` → `npm run test:db` を実行し、`1..76` 全て `ok`（`Files=4, Tests=151, Result: PASS`）
- [x] 負のテストA: RLS未設定の新規テーブルを作成 → `tables_are`（Extra tables）・`is_empty`（Unexpected records）の両方が失敗することを確認
- [x] 負のテストB: 既存テーブル`plants`のRLSを無効化 → `tables_are`は通過、`is_empty`のみ失敗することを確認（2つの断言が独立に必要であることの実証）
- [x] 上記の検証用スキーマ変更はすべて元に戻し、`supabase db reset`でクリーンな状態にした上で最終確認済み
- [ ] CI（`playwright.yml`の`Run pgTAP database tests`ステップ）でも通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)