### PR TITLE
UIレビュー優先度高(🔴 #1〜8)の修正を実装

### DIFF
--- a/.claude/plans/iterative-petting-pillow.md
+++ b/.claude/plans/iterative-petting-pillow.md
@@ -1,81 +1,65 @@
-# UIレビュー優先度高(🔴 #1〜8)の修正プラン
+# UIレビュー 🟡操作性(#9〜16)の改善プラン
 
 ## Context
 
-UIレビュー(本セッション前半、実機スクリーンショット48枚+コードレビュー)で洗い出した改善点のうち、ユーザー指示「優先度高いもの」= 🔴 8件を修正する。
+UIレビュー(本セッション、実機スクリーンショット48枚+全画面コードレビュー)の優先度高🔴8件は実装済み(PR #108、コミット `9ba9ef7`〜`3303392`)。本プランはその続き=優先度提案「次のスプリント(操作性)」**#9〜16**を対応する。モバイル操作性が中心で、フォトSNSとして最も使われるスマホでの日常操作(回遊・投稿・いいね)の使い勝手を引き上げる。
 
-- **#1〜5**: スマホ(390px)で実際に崩れている表示バグ
-- **#6〜8**: 機能として壊れているUI
+前提: 検証環境は構築済み(ローカルSupabase+dev server+Playwright撮影スクリプト)。ブランチは `claude/ui-improvement-review-110nnk`(push すると PR #108 が自動更新される)。
 
-#6はユーザー確認済み: **usersテーブルにbioカラムを追加し、保存+公開プロフィール表示まで実装**。
+## 変更内容
 
-検証環境は構築済み: ローカルSupabase(54321/54322)+dev server(localhost:3000)起動中、シード済み、Playwright撮影スクリプトあり(`scratchpad/shoot.js`)。ブランチ `claude/ui-improvement-review-110nnk` チェックアウト済み。
+### 1. #9+#10: モバイルを下部固定タブバーに再編 — コミット1
 
-## Phase 1: モバイル表示崩れのCSS修正(#1〜5) — コミット1
+**新規 `src/components/BottomNav.tsx`**(client component):
+- 5項目: フィード(`/`)・図鑑(`/zukan`)・**投稿(`/posts/new`、中央の強調ボタン)**・さがす(`/plants`)・マイページ(ログイン時 `/{aliasId}`、未ログイン時 `/signin`)
+- `fixed bottom-0 inset-x-0 z-40 sm:hidden bg-white border-t border-border`、セーフエリア対応 `pb-[env(safe-area-inset-bottom)]`
+- アイコン+テキストラベル(text-[10px])の縦積み。`usePathname()`でアクティブ状態(HeaderNavの`isActive`ロジックを踏襲)。各リンク高さ≥44px(`py-2`+アイコン20px+ラベル)
+- 中央の投稿ボタンは円形グリーン(`bg-green-600 text-white rounded-full w-12 h-12 -mt-4 shadow`)。未ログインタップ時は既存middleware(`src/middleware.ts` の `/posts/new` 保護)が `/signin` へ誘導するのでクライアント側の分岐は不要
+- `data-testid="bottom-nav"` と各項目にtestidを付与(E2E用)
 
-1. **図鑑行の「N匹」見切れ** `src/app/zukan/page.tsx:88-104` — モバイルは2行に折る(sm以上は現状と完全同一):
-   - 行Link: `flex items-center gap-4 px-5 py-3.5` → `flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 sm:flex-nowrap sm:gap-4 sm:px-5 sm:py-3.5`
-   - 名前span: `w-36 shrink-0 ...` → `flex-1 min-w-0 ... sm:flex-none sm:w-36`(`min-w-0`を落とさない=truncate維持)
-   - バーspan: `flex-1 min-w-[60px]` → `order-last w-full sm:order-none sm:w-auto sm:flex-1 sm:min-w-[60px]`
-   - No・匹数・バッジ等は無変更。`data-testid="zukan-row"`とテキスト維持(e2e/search-zukan.test.ts:74-88はレイアウト非依存で影響なし)
-2. **カタログ表ラベル縦割れ** `src/app/plants/[id]/page.tsx:206-224` — 6つの`dt`に`whitespace-nowrap`追加
-3. **設定タブ折り返し** `src/app/settings/layout.tsx:21-55` — タブ行に`overflow-x-auto`、各タブ`shrink-0 whitespace-nowrap text-sm`。あわせて不正な`<Link><button>`入れ子を`<Link className=...>`直スタイルへ(見た目同一。text-smはPCでも16→14pxになるが許容)
-4. **フッター折り返し** `src/components/Footer.tsx:7-11` — `flex flex-wrap justify-center gap-x-4 gap-y-2`+各リンク`whitespace-nowrap`
-5. **iOS入力ズーム** `src/components/ui/input.tsx:13` — `text-sm`→`text-base md:text-sm`(textarea.tsx:12と同一パターン。使用箇所でのサイズ上書きなしを確認済み)
+**組み込み**(`src/components/Header.tsx`):
+- Header(server component、既に `getUserProfileByAuthId()` 取得済み)がフラグメントで `<BottomNav aliasId={...} isLoggedIn={...} />` を併せて返す(fixed配置なのでDOM上はheader内でも問題ない。プロフィール取得の重複クエリを増やさない)
+- ヘッダー側のモバイル表示を整理: `HeaderNav` に `max-sm:hidden`(アイコンのみで意味不明だった3リンクはタブバーに移管)、モバイル用カメラボタン(`Header.tsx:46-50`)を削除(中央の投稿タブに移管)。**デスクトップは無変更**
 
-## Phase 2: bio保存対応(#6) — コミット2(DB) + コミット3(アプリ)
+**下部バーとの重なり回避**(`src/app/layout.tsx`): `<main>` に `max-sm:pb-20` を追加(フッター最下部がタブバーに隠れないように)
 
-**DB(CLAUDE.md手順厳守。`prisma db push`/`prisma migrate`禁止)**:
-```
-npx supabase migration new add_users_bio   # SQL: alter table public.users add column bio varchar;
-npx supabase db reset
-npm run db:pull      # schema.prisma差分が public_users.bio 1行のみなこと確認(他が出たら停止して報告)
-npm run seed:e2e     # resetで消えるため再投入
-# dev server再起動(Prisma Client再生成の反映)
-```
-- RLS/ポリシー/一意Index変更なし → pgTAP更新不要(構造テストは列を検査しないことを確認済み)
-- コミット2 = migration SQL + schema.prisma のセット
+### 2. #11+#12+#16: フィードカードの操作性 — コミット2
 
-**アプリ側(コミット3)**:
-- `src/lib/const.ts`: `MAX_USER_BIO_LENGTH = 300` 追加
-- `src/actions/user-action.ts`:
-  - `getUserProfile`(:21): selectに`bio: true`、返却に`bio: userData.bio ?? undefined`
-  - `getUserProfileByAuthId`(:52): 返却に`bio`追加(select無しのため返却のみ)
-  - `updateUser(name, aliasId, bio?: string)`(:150): 既存throwスタイルで検証を追加し、**bio未指定時に既存値を消さない**条件スプレッドで更新:
-    `data: { name, alias_id: aliasId, ...(bio !== undefined ? { bio: bio.trim() || null } : {}) }`(空文字はnull化)。
-    `revalidatePath("/settings/profile")`に加え`revalidatePath(\`/${aliasId}\`)`も実行(公開プロフィールの古いbio/名前対策)
-- `src/app/settings/profile/AccountPageContent.tsx`:
-  - zod: `bio: z.string().max(MAX_USER_BIO_LENGTH, ...).optional()`追加、nameのmaxメッセージ「7文字以内」→「20文字以内」に修正
-  - **aliasIdのclient/server検証不一致も同時修正**(client `/^[a-zA-Z0-9]+$/`・server `/^[a-zA-Z]+$/`(:180)。数字入りが汎用エラートーストになる罠。zodをサーバに合わせ`/^[a-zA-Z]+$/`+メッセージ「ユーザーIDは半角英字で…」にし、「表示名」表記も「ユーザーID」へ)
-  - `defaultValues`に`bio: userProfile.bio ?? ""`追加、3フィールドとも`defaultValue`/`value`/`onChange`を削除し`{...field}`化(controlled/uncontrolled警告の根治)、Textareaに`maxLength`
-  - submit: `updateUser(formData.name, formData.aliasId, formData.bio)`
-- `src/app/[aliasId]/page.tsx`(:112直後): `{userProfile.bio && <p className="pt-1 text-sm text-gray-600 whitespace-pre-wrap break-words">…</p>}`
-- テスト `src/__test__/actions/user-action.test.ts`(:164-): bio 301字で`rejects`+update未呼び出し、bio付き正常系(`'こんにちは'`→そのまま/空白のみ→`null`)を追加。既存正常系は条件スプレッド採用により無変更でpass
-- doc: `doc/03-architecture/data-model.md`のusers行にbioを追記(doc/README対応表に従う。security.mdはカラム列挙なしのため対象外)
+- **#11 いいねのタップ領域**(`src/components/np/LikeButton.tsx`): buttonに `p-2 -m-2`(見た目不変で実効44px確保)。投稿詳細(size="lg")も同様
+- **#12 モバイルで猫チップ表示**(`src/components/np/PostCard.tsx:52-61`): ヘッダー右の猫チップ(`max-sm:hidden`)はデスクトップ用に維持し、本文セクション(植物タグの行の上)に `sm:hidden` の猫チップ行を追加(モバイルでも「猫×植物」の中核情報が見えるように)。3匹以上の「+N」表記は既存ロジックを共通化して流用
+- **#16 共存バッジをタップ可能に**(`PostCard.tsx:95-103`): PlantTag横の `CoexistBadge` を `<Link href={/plants/${plant.id}} className="pointer-events-auto">` でラップ(現状はタップすると意図せず投稿詳細に飛ぶ。バッジ=実績表示なので植物ページへ)。CoexistBadge自体は無変更
 
-## Phase 3: /newsクラッシュ対策(#7) — コミット4
+### 3. #13+#15: 行き止まりの解消 — コミット3
 
-- `src/actions/news-action.ts:40-47`: `getNews()`のcatchで`throw`→`return []`(console.error維持)。目的は/newsページの白画面解消(news/page.tsxは空配列で「お知らせはありません」表示済み。sitemap.tsは既にtry/catch済みで影響なし)。`getNewsById`はthrow維持
-- `src/app/error.tsx` **新規作成**: `"use client"`、`{ error, reset }`を受ける標準エラーバウンダリ。not-found.tsxと同じトーン(PawPrint+「一時的な問題が発生しました」+`reset()`再試行ボタン+ホームへ戻る)。エラー内容は画面に出さずconsoleのみ。root layout自体のエラーは対象外(layoutはデータ取得をしないため許容)
+- **#13 検索0件時の導線**(`src/components/np/EmptyState.tsx` + `src/app/plants/page.tsx`):
+  - EmptyStateに任意の `action?: React.ReactNode` propを追加(テキスト下に描画するだけの小変更)
+  - /plants の植物タブ0件時: 「共存図鑑で全植物を見る」ボタン(→`/zukan`)+「投稿時には新しい植物名を登録できます」の補足文を action で渡す。投稿タブ0件時: 「絞り込みを解除する」リンク(→`/plants?tab=posts`)
+- **#15 投稿ボタンの無効理由**(`src/app/posts/new/PostFlow.tsx:582-601` フッターナビ):
+  - `!canSubmit && !isSubmitting` のとき、ボタンの上に不足項目を1行表示: 「あと 写真の選択 / 植物の選択 / 猫の選択 が必要です」(photoDone/plantDone/petDone から未完了のものだけを列挙、`text-xs text-gray-500`)。全て揃えば消える
 
-## Phase 4: /contactフォールバック(#8) — コミット5
+### 4. #14 ページネーション(もっと見る/無限スクロール)は**今回見送り**
 
-`src/app/contact/page.tsx`: iframeに`title="お問い合わせフォーム"`、下に「フォームが表示されない場合は こちら」リンク(`/ebd/`を除いた通常URL `https://confirmed-giant-27d.notion.site/1c69f17f06688007995fc3497043f841` を`target="_blank" rel="noopener noreferrer"`で)
+フィードのデータ取得をクライアント追記型に作り替える必要があり(サーバーコンポーネント→client feed への再設計)、このトランシェの他7件と粒度が違うため。レビュー報告どおり中期課題として別PRを推奨。
+
+## E2Eへの影響(実装時に必ず確認)
+
+- `@mobile` タグのE2E(`playwright.config.ts:59-65`、Pixel 5)がヘッダーナビ/カメラボタンをタップしている場合、下部タブバーのtestidに差し替える(`e2e/navigation.test.ts`・`e2e/feed.test.ts`・`e2e/post-flow.test.ts` を実装前にgrepし、`max-sm:hidden` 化した要素への依存を洗い出す)
+- PostCardの構造変更(#12/#16)は `post-card-link` オーバーレイのクリック領域に影響しないこと(`pointer-events-auto` の付け忘れに注意)
 
 ## 検証
 
-1. `npm run lint` / `npm test` / `npm run build` すべてpass
+1. `npm run lint` / `npm test` / `npm run build`
 2. Playwright再撮影(390x844 + 1440x900):
-   - /zukan: 全行で「N匹」が見切れない(モバイル2行化)。**PCは修正前と同一**
-   - /plants/[id]: カタログ表のラベルが横書き1行
-   - /settings/*: タブが語中で折れない
-   - フッター: 項目単位で折り返し
-   - /contact: フォールバックリンク表示
-3. bio実機フロー(/signin/dev → e2e@example.com/password): 設定で自己紹介入力→保存→リロードで残存→公開プロフィール`/testuser`に表示。空で保存→表示が消える(null)。/settings/profileでコンソール警告が出ない
-4. /news: ローカル(Notion未設定)で白画面にならず「お知らせはありません」
-5. e2e必要時: `npm run e2e -- --grep @public`(search-zukan含む)
+   - モバイル: 全主要ページで下部タブバー表示・アクティブ状態・フッターが隠れない・ヘッダーがロゴ+ログイン/アバターだけになる
+   - デスクトップ: ヘッダー/フィードが**修正前と同一**(回帰なし)
+   - フィード: モバイルで猫チップが本文に表示、いいねタップ領域、バッジタップで植物ページへ遷移
+   - /plants?q=存在しない名前: 0件導線(図鑑ボタン)表示
+   - /posts/new: 写真だけ選んだ状態で「あと 植物の選択 / 猫の選択 が必要です」表示→全選択で消えて投稿可能
+3. E2E: `npm run e2e -- --grep @mobile` と `--grep @public` をローカル実行し、必要なら selector を更新
+4. push(PR #108 が自動更新される)
 
-## コミット/プッシュ
+## コミット構成
 
-- 5コミット構成(上記Phase単位)、ブランチ `claude/ui-improvement-review-110nnk` へ `git push -u origin`
-- `.env.local`(gitignore済み)と`supabase/storage/`空ディレクトリ(git管理外)は含めない。PRは指示があるまで作らない
+1. `feat(nav): モバイルに下部タブバーを追加しヘッダーを整理`(BottomNav新規、Header/HeaderNav/layout調整、E2E selector追随)
+2. `fix(feed): カードの操作性改善`(いいねタップ領域、モバイル猫チップ、共存バッジのリンク化)
+3. `fix(ux): 検索0件と投稿フォームの行き止まりを解消`(EmptyState action、投稿ボタンの不足項目ヒント)

--- a/.claude/plans/iterative-petting-pillow.md
+++ b/.claude/plans/iterative-petting-pillow.md
@@ -1,0 +1,81 @@
+# UIレビュー優先度高(🔴 #1〜8)の修正プラン
+
+## Context
+
+UIレビュー(本セッション前半、実機スクリーンショット48枚+コードレビュー)で洗い出した改善点のうち、ユーザー指示「優先度高いもの」= 🔴 8件を修正する。
+
+- **#1〜5**: スマホ(390px)で実際に崩れている表示バグ
+- **#6〜8**: 機能として壊れているUI
+
+#6はユーザー確認済み: **usersテーブルにbioカラムを追加し、保存+公開プロフィール表示まで実装**。
+
+検証環境は構築済み: ローカルSupabase(54321/54322)+dev server(localhost:3000)起動中、シード済み、Playwright撮影スクリプトあり(`scratchpad/shoot.js`)。ブランチ `claude/ui-improvement-review-110nnk` チェックアウト済み。
+
+## Phase 1: モバイル表示崩れのCSS修正(#1〜5) — コミット1
+
+1. **図鑑行の「N匹」見切れ** `src/app/zukan/page.tsx:88-104` — モバイルは2行に折る(sm以上は現状と完全同一):
+   - 行Link: `flex items-center gap-4 px-5 py-3.5` → `flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 sm:flex-nowrap sm:gap-4 sm:px-5 sm:py-3.5`
+   - 名前span: `w-36 shrink-0 ...` → `flex-1 min-w-0 ... sm:flex-none sm:w-36`(`min-w-0`を落とさない=truncate維持)
+   - バーspan: `flex-1 min-w-[60px]` → `order-last w-full sm:order-none sm:w-auto sm:flex-1 sm:min-w-[60px]`
+   - No・匹数・バッジ等は無変更。`data-testid="zukan-row"`とテキスト維持(e2e/search-zukan.test.ts:74-88はレイアウト非依存で影響なし)
+2. **カタログ表ラベル縦割れ** `src/app/plants/[id]/page.tsx:206-224` — 6つの`dt`に`whitespace-nowrap`追加
+3. **設定タブ折り返し** `src/app/settings/layout.tsx:21-55` — タブ行に`overflow-x-auto`、各タブ`shrink-0 whitespace-nowrap text-sm`。あわせて不正な`<Link><button>`入れ子を`<Link className=...>`直スタイルへ(見た目同一。text-smはPCでも16→14pxになるが許容)
+4. **フッター折り返し** `src/components/Footer.tsx:7-11` — `flex flex-wrap justify-center gap-x-4 gap-y-2`+各リンク`whitespace-nowrap`
+5. **iOS入力ズーム** `src/components/ui/input.tsx:13` — `text-sm`→`text-base md:text-sm`(textarea.tsx:12と同一パターン。使用箇所でのサイズ上書きなしを確認済み)
+
+## Phase 2: bio保存対応(#6) — コミット2(DB) + コミット3(アプリ)
+
+**DB(CLAUDE.md手順厳守。`prisma db push`/`prisma migrate`禁止)**:
+```
+npx supabase migration new add_users_bio   # SQL: alter table public.users add column bio varchar;
+npx supabase db reset
+npm run db:pull      # schema.prisma差分が public_users.bio 1行のみなこと確認(他が出たら停止して報告)
+npm run seed:e2e     # resetで消えるため再投入
+# dev server再起動(Prisma Client再生成の反映)
+```
+- RLS/ポリシー/一意Index変更なし → pgTAP更新不要(構造テストは列を検査しないことを確認済み)
+- コミット2 = migration SQL + schema.prisma のセット
+
+**アプリ側(コミット3)**:
+- `src/lib/const.ts`: `MAX_USER_BIO_LENGTH = 300` 追加
+- `src/actions/user-action.ts`:
+  - `getUserProfile`(:21): selectに`bio: true`、返却に`bio: userData.bio ?? undefined`
+  - `getUserProfileByAuthId`(:52): 返却に`bio`追加(select無しのため返却のみ)
+  - `updateUser(name, aliasId, bio?: string)`(:150): 既存throwスタイルで検証を追加し、**bio未指定時に既存値を消さない**条件スプレッドで更新:
+    `data: { name, alias_id: aliasId, ...(bio !== undefined ? { bio: bio.trim() || null } : {}) }`(空文字はnull化)。
+    `revalidatePath("/settings/profile")`に加え`revalidatePath(\`/${aliasId}\`)`も実行(公開プロフィールの古いbio/名前対策)
+- `src/app/settings/profile/AccountPageContent.tsx`:
+  - zod: `bio: z.string().max(MAX_USER_BIO_LENGTH, ...).optional()`追加、nameのmaxメッセージ「7文字以内」→「20文字以内」に修正
+  - **aliasIdのclient/server検証不一致も同時修正**(client `/^[a-zA-Z0-9]+$/`・server `/^[a-zA-Z]+$/`(:180)。数字入りが汎用エラートーストになる罠。zodをサーバに合わせ`/^[a-zA-Z]+$/`+メッセージ「ユーザーIDは半角英字で…」にし、「表示名」表記も「ユーザーID」へ)
+  - `defaultValues`に`bio: userProfile.bio ?? ""`追加、3フィールドとも`defaultValue`/`value`/`onChange`を削除し`{...field}`化(controlled/uncontrolled警告の根治)、Textareaに`maxLength`
+  - submit: `updateUser(formData.name, formData.aliasId, formData.bio)`
+- `src/app/[aliasId]/page.tsx`(:112直後): `{userProfile.bio && <p className="pt-1 text-sm text-gray-600 whitespace-pre-wrap break-words">…</p>}`
+- テスト `src/__test__/actions/user-action.test.ts`(:164-): bio 301字で`rejects`+update未呼び出し、bio付き正常系(`'こんにちは'`→そのまま/空白のみ→`null`)を追加。既存正常系は条件スプレッド採用により無変更でpass
+- doc: `doc/03-architecture/data-model.md`のusers行にbioを追記(doc/README対応表に従う。security.mdはカラム列挙なしのため対象外)
+
+## Phase 3: /newsクラッシュ対策(#7) — コミット4
+
+- `src/actions/news-action.ts:40-47`: `getNews()`のcatchで`throw`→`return []`(console.error維持)。目的は/newsページの白画面解消(news/page.tsxは空配列で「お知らせはありません」表示済み。sitemap.tsは既にtry/catch済みで影響なし)。`getNewsById`はthrow維持
+- `src/app/error.tsx` **新規作成**: `"use client"`、`{ error, reset }`を受ける標準エラーバウンダリ。not-found.tsxと同じトーン(PawPrint+「一時的な問題が発生しました」+`reset()`再試行ボタン+ホームへ戻る)。エラー内容は画面に出さずconsoleのみ。root layout自体のエラーは対象外(layoutはデータ取得をしないため許容)
+
+## Phase 4: /contactフォールバック(#8) — コミット5
+
+`src/app/contact/page.tsx`: iframeに`title="お問い合わせフォーム"`、下に「フォームが表示されない場合は こちら」リンク(`/ebd/`を除いた通常URL `https://confirmed-giant-27d.notion.site/1c69f17f06688007995fc3497043f841` を`target="_blank" rel="noopener noreferrer"`で)
+
+## 検証
+
+1. `npm run lint` / `npm test` / `npm run build` すべてpass
+2. Playwright再撮影(390x844 + 1440x900):
+   - /zukan: 全行で「N匹」が見切れない(モバイル2行化)。**PCは修正前と同一**
+   - /plants/[id]: カタログ表のラベルが横書き1行
+   - /settings/*: タブが語中で折れない
+   - フッター: 項目単位で折り返し
+   - /contact: フォールバックリンク表示
+3. bio実機フロー(/signin/dev → e2e@example.com/password): 設定で自己紹介入力→保存→リロードで残存→公開プロフィール`/testuser`に表示。空で保存→表示が消える(null)。/settings/profileでコンソール警告が出ない
+4. /news: ローカル(Notion未設定)で白画面にならず「お知らせはありません」
+5. e2e必要時: `npm run e2e -- --grep @public`(search-zukan含む)
+
+## コミット/プッシュ
+
+- 5コミット構成(上記Phase単位)、ブランチ `claude/ui-improvement-review-110nnk` へ `git push -u origin`
+- `.env.local`(gitignore済み)と`supabase/storage/`空ディレクトリ(git管理外)は含めない。PRは指示があるまで作らない

--- a/doc/03-architecture/data-model.md
+++ b/doc/03-architecture/data-model.md
@@ -37,7 +37,7 @@ erDiagram
 | `pets` | 飼い猫のプロフィール | 名前・猫種・写真・年齢・誕生日・性別 |
 | `neko` | 猫種マスタ | `name` に一意制約。マイグレーションで投入（49種）。書き込みAPIを持たない運用マスタ |
 
-`users.alias_id` は URL に使う短い識別子（`/[aliasId]`）。`users.role` は `'user'`（既定）または `'admin'`。
+`users.alias_id` は URL に使う短い識別子（`/[aliasId]`）。`users.role` は `'user'`（既定）または `'admin'`。`users.bio` は自己紹介（任意。上限 `MAX_USER_BIO_LENGTH` = 300文字はアプリ側で検証し、公開プロフィールに表示される）。
 
 ### 投稿
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,7 @@ model public_users {
   image                     String?                     @db.VarChar
   created_at                DateTime                    @default(now()) @db.Timestamptz(6)
   role                      String?                     @default("user") @db.VarChar(50)
+  bio                       String?                     @db.VarChar
   pets                      pets[]
   plant_identification_logs plant_identification_logs[]
   post_likes                post_likes[]

--- a/src/__test__/actions/user-action.test.ts
+++ b/src/__test__/actions/user-action.test.ts
@@ -207,6 +207,44 @@ describe('User Actions', () => {
                 data: { name: '新しい名前', alias_id: 'newalias' },
             });
         });
+
+        it('自己紹介が301文字以上の場合はエラー', async () => {
+            mockSupabase(mockUser);
+            vi.mocked(prisma.public_users.findFirst).mockResolvedValue(mockPublicUser as any);
+
+            await expect(updateUser('テスト', 'testuser', 'あ'.repeat(301))).rejects.toThrow(
+                '自己紹介は300文字以内で入力してください'
+            );
+            expect(prisma.public_users.update).not.toHaveBeenCalled();
+        });
+
+        it('正常系: 自己紹介つきで更新する', async () => {
+            mockSupabase(mockUser);
+            vi.mocked(prisma.public_users.findFirst)
+                .mockResolvedValueOnce(mockPublicUser as any)
+                .mockResolvedValueOnce(null);
+
+            await updateUser('新しい名前', 'newalias', 'こんにちは');
+
+            expect(prisma.public_users.update).toHaveBeenCalledWith({
+                where: { id: 1 },
+                data: { name: '新しい名前', alias_id: 'newalias', bio: 'こんにちは' },
+            });
+        });
+
+        it('自己紹介が空白のみの場合はnullとして保存する', async () => {
+            mockSupabase(mockUser);
+            vi.mocked(prisma.public_users.findFirst)
+                .mockResolvedValueOnce(mockPublicUser as any)
+                .mockResolvedValueOnce(null);
+
+            await updateUser('新しい名前', 'newalias', '   ');
+
+            expect(prisma.public_users.update).toHaveBeenCalledWith({
+                where: { id: 1 },
+                data: { name: '新しい名前', alias_id: 'newalias', bio: null },
+            });
+        });
     });
 
     describe('updateUserImage', () => {

--- a/src/actions/news-action.ts
+++ b/src/actions/news-action.ts
@@ -41,8 +41,10 @@ export async function getNews(): Promise<NewsItem[]> {
     try {
         return await fetchNewsList();
     } catch (error) {
+        // Notion 側の障害や未設定で /news 全体が落ちないよう、一覧は空として扱う
+        // (ページ側は「お知らせはありません」を表示する。sitemap も同様に空でよい)
         console.error("Failed to fetch news:", error);
-        throw new Error("Failed to fetch news");
+        return [];
     }
 }
 

--- a/src/actions/user-action.ts
+++ b/src/actions/user-action.ts
@@ -3,7 +3,7 @@
 import { Pet, SexType } from "@/types/neko";
 import { UserProfile } from "@/types/user";
 import { UserPlantCollectionItem, UserStats } from "@/types/post";
-import { MAX_PET_NAME_LENGTH, STORAGE_PATH } from "@/lib/const";
+import { MAX_PET_NAME_LENGTH, MAX_USER_BIO_LENGTH, STORAGE_PATH } from "@/lib/const";
 import { isValidOwnedImagePath } from "@/lib/storage-path";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
@@ -26,6 +26,7 @@ export async function getUserProfile(aliasId: string): Promise<UserProfile | und
             auth_id: true,
             name: true,
             image: true,
+            bio: true,
         },
         where: {
             alias_id: aliasId,
@@ -45,6 +46,7 @@ export async function getUserProfile(aliasId: string): Promise<UserProfile | und
         aliasId: userData.alias_id,
         name: userData.name,
         imageSrc: userData.image ? STORAGE_PATH.USER_PROFILE + userData.image : undefined,
+        bio: userData.bio ?? undefined,
         isSelf: user != null && user.id === userData.auth_id,
     };
 }
@@ -75,6 +77,7 @@ export async function getUserProfileByAuthId(): Promise<UserProfile | undefined>
         aliasId: userData.alias_id,
         name: userData.name,
         imageSrc: userData.image ? STORAGE_PATH.USER_PROFILE + userData.image : undefined,
+        bio: userData.bio ?? undefined,
         isSelf: true,
     };
 }
@@ -147,7 +150,7 @@ export async function getPublicUserPets(userId: number): Promise<Pet[] | undefin
     }));
 }
 
-export async function updateUser(name: string, aliasId: string) {
+export async function updateUser(name: string, aliasId: string, bio?: string) {
     const supabase = await createClient();
 
     const {
@@ -186,6 +189,11 @@ export async function updateUser(name: string, aliasId: string) {
         throw new Error("このユーザーIDは使用できません");
     }
 
+    const trimmedBio = bio?.trim();
+    if (trimmedBio && trimmedBio.length > MAX_USER_BIO_LENGTH) {
+        throw new Error(`自己紹介は${MAX_USER_BIO_LENGTH}文字以内で入力してください`);
+    }
+
     // 大文字小文字違いも含めて重複を拒否 (DB側にも lower(alias_id) の一意制約あり)
     const duplicated = await prisma.public_users.findFirst({
         where: {
@@ -198,7 +206,7 @@ export async function updateUser(name: string, aliasId: string) {
         throw new Error("このユーザーIDは既に使用されています");
     }
 
-    // ユーザー情報を更新
+    // ユーザー情報を更新 (bio は引数で渡されたときだけ更新し、省略時は既存値を保持する)
     await prisma.public_users.update({
         where: {
             id: userData.id,
@@ -206,10 +214,13 @@ export async function updateUser(name: string, aliasId: string) {
         data: {
             name: name,
             alias_id: aliasId,
+            ...(bio !== undefined ? { bio: trimmedBio || null } : {}),
         },
     });
 
     revalidatePath(`/settings/profile`);
+    // 公開プロフィールにも名前・自己紹介が表示されるためキャッシュを破棄する
+    revalidatePath(`/${aliasId}`);
 }
 
 /** クライアントが user_profiles バケットへ直接アップロード済みのパスを受け取る */

--- a/src/app/[aliasId]/page.tsx
+++ b/src/app/[aliasId]/page.tsx
@@ -120,6 +120,11 @@ export default async function ProfilePage({
               <strong className="text-gray-900">{stats.plantCount}</strong> 植物
             </span>
           </div>
+          {userProfile.bio && (
+            <p className="pt-1 text-sm text-gray-600 whitespace-pre-wrap break-words">
+              {userProfile.bio}
+            </p>
+          )}
         </div>
         {isSelf && (
           <div className="flex gap-2 flex-wrap">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -14,10 +14,24 @@ export default function ContactPage() {
         <CardContent>
           <iframe
             src="https://confirmed-giant-27d.notion.site/ebd/1c69f17f06688007995fc3497043f841"
+            title="お問い合わせフォーム"
             width="100%"
             height="1280"
             allowFullScreen
           />
+          {/* 埋め込みがブロックされる環境 (広告ブロッカー等) 向けの逃げ道 */}
+          <p className="mt-4 text-sm text-muted-foreground text-center">
+            フォームが表示されない場合は{" "}
+            <a
+              href="https://confirmed-giant-27d.notion.site/1c69f17f06688007995fc3497043f841"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline"
+            >
+              こちら
+            </a>
+            {" "}からお問い合わせください。
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { PawPrint } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * グローバルエラーバウンダリ。
+ * RSCやServer Actionの予期しない例外で素のNext.jsエラー画面 (白画面) を
+ * 見せないためのフォールバック。エラー内容は画面に出さない。
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-20 flex flex-col items-center gap-4 text-center">
+      <PawPrint className="w-12 h-12 text-green-600" />
+      <h1 className="text-2xl font-bold text-gray-900">問題が発生しました</h1>
+      <p className="text-sm text-gray-600 leading-normal">
+        一時的な問題が発生しました。時間をおいて再度お試しください。
+      </p>
+      <div className="flex gap-3 flex-wrap justify-center">
+        <Button className="bg-green-600 hover:bg-green-700" onClick={reset}>
+          再試行
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/">ホームへ戻る</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -204,20 +204,20 @@ export default async function PlantPage({
       <div className="bg-white rounded-xl border border-border shadow-sm p-5 flex flex-col gap-3">
         <h2 className="text-base font-semibold text-gray-900">カタログ情報</h2>
         <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
-          <dt className="text-gray-500">学名</dt>
+          <dt className="text-gray-500 whitespace-nowrap">学名</dt>
           <dd className="text-gray-800 italic">{plant.scientific_name ?? "—"}</dd>
-          <dt className="text-gray-500">科名</dt>
+          <dt className="text-gray-500 whitespace-nowrap">科名</dt>
           <dd className="text-gray-800">{plant.family ?? "—"}</dd>
-          <dt className="text-gray-500">観測された投稿</dt>
+          <dt className="text-gray-500 whitespace-nowrap">観測された投稿</dt>
           <dd className="text-gray-800">{plant.postCount} 件</dd>
-          <dt className="text-gray-500">ユニークな猫</dt>
+          <dt className="text-gray-500 whitespace-nowrap">ユニークな猫</dt>
           <dd className="text-gray-800">
             {plant.catCount} 匹
             <span className="ml-2 text-xs text-gray-400">同一ユーザーの重複投稿では水増しされません</span>
           </dd>
-          <dt className="text-gray-500">外部データ照合</dt>
+          <dt className="text-gray-500 whitespace-nowrap">外部データ照合</dt>
           <dd className="text-gray-800">—（今後対応予定）</dd>
-          <dt className="text-gray-500">共存実績</dt>
+          <dt className="text-gray-500 whitespace-nowrap">共存実績</dt>
           <dd>
             <CoexistBadge catCount={plant.catCount} />
           </dd>

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Metadata } from "next";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { BookHeart, ChevronLeft, ChevronRight } from "lucide-react";
 import { searchPlants, PlantFilter, PlantSortBy } from "@/actions/plant-action";
 import { searchPosts } from "@/actions/post-action";
 import { getNekoSpecies } from "@/actions/neko-action";
@@ -126,7 +126,22 @@ export default async function PlantsSearchPage({
             ))}
           </div>
         ) : (
-          <EmptyState text="植物が見つかりませんでした" />
+          <EmptyState
+            text="植物が見つかりませんでした"
+            action={
+              <>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/zukan">
+                    <BookHeart className="w-4 h-4" />
+                    共存図鑑で全植物を見る
+                  </Link>
+                </Button>
+                <p className="text-xs text-gray-400">
+                  投稿するときに、新しい植物名を登録できます
+                </p>
+              </>
+            }
+          />
         )
       ) : postsResult.posts.length > 0 ? (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
@@ -135,7 +150,17 @@ export default async function PlantsSearchPage({
           ))}
         </div>
       ) : (
-        <EmptyState icon="image" text="条件に合う投稿がありません" />
+        <EmptyState
+          icon="image"
+          text="条件に合う投稿がありません"
+          action={
+            (query || params.neko) && (
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/plants?tab=posts">絞り込みを解除する</Link>
+              </Button>
+            )
+          }
+        />
       )}
 
       {/* ページネーション */}

--- a/src/app/posts/new/PostFlow.tsx
+++ b/src/app/posts/new/PostFlow.tsx
@@ -259,6 +259,13 @@ export default function PostFlow({
   const canSubmit =
     photoDone && plantDone && petDone && !isProcessingImages && !isSubmitting;
 
+  // 投稿ボタンが押せない理由を明示するための不足項目リスト
+  const missingSteps = [
+    !photoDone && "写真の選択",
+    !plantDone && "植物の選択",
+    !petDone && "猫の選択",
+  ].filter((step): step is string => Boolean(step));
+
   const onSubmit = async () => {
     setIsSubmitting(true);
     let uploadedPaths: string[] = [];
@@ -578,6 +585,13 @@ export default function PostFlow({
         <p className="p-3 rounded-md bg-gray-50 text-xs text-gray-500 leading-normal">
           投稿すると、植物の共存実績にすぐ反映されます。
         </p>
+
+        {/* 投稿ボタンが無効な理由 (不足項目) を明示する */}
+        {missingSteps.length > 0 && (
+          <p className="text-xs text-gray-500 text-right" data-testid="submit-hint">
+            あと <span className="font-semibold">{missingSteps.join(" / ")}</span> をすると投稿できます
+          </p>
+        )}
 
         {/* フッターナビ */}
         <div className="flex justify-between pt-2 border-t border-border">

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -18,40 +18,25 @@ export default function SettingsLayout({
         <div className="max-w-4xl mx-auto space-y-8 mt-4 mb-4">
           <div className="bg-white rounded-xl shadow-lg p-6">
             <h1 className="text-2xl font-bold mb-6">各種設定</h1>
-            <div className="flex items-center gap-2 mb-4 border-b">
-              <Link href="/settings/account">
-                <button
-                  className={`px-4 py-2 ${
-                    isActive("/settings/account")
+            {/* ラベルが語中で折り返さないよう nowrap にし、入り切らない幅では横スクロールさせる */}
+            <div className="flex items-center gap-2 mb-4 border-b overflow-x-auto">
+              {[
+                { href: "/settings/account", label: "アカウント" },
+                { href: "/settings/profile", label: "プロフィール" },
+                { href: "/settings/cats", label: "猫プロフィール" },
+              ].map((tab) => (
+                <Link
+                  key={tab.href}
+                  href={tab.href}
+                  className={`shrink-0 whitespace-nowrap px-4 py-2 text-sm ${
+                    isActive(tab.href)
                       ? "text-black border-b-2 border-green-500"
                       : "text-black hover:text-gray-600"
                   }`}
                 >
-                  アカウント
-                </button>
-              </Link>
-              <Link href="/settings/profile">
-                <button
-                  className={`px-4 py-2 ${
-                    isActive("/settings/profile")
-                      ? "text-black border-b-2 border-green-500"
-                      : "text-black hover:text-gray-600"
-                  }`}
-                >
-                  プロフィール
-                </button>
-              </Link>
-              <Link href="/settings/cats">
-                <button
-                  className={`px-4 py-2 ${
-                    isActive("/settings/cats")
-                      ? "text-black border-b-2 border-green-500"
-                      : "text-black hover:text-gray-600"
-                  }`}
-                >
-                  猫プロフィール
-                </button>
-              </Link>
+                  {tab.label}
+                </Link>
+              ))}
             </div>
 
             {children}

--- a/src/app/settings/profile/AccountPageContent.tsx
+++ b/src/app/settings/profile/AccountPageContent.tsx
@@ -22,6 +22,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import Image from "next/image";
 import { updateUser } from "@/actions/user-action";
+import { MAX_USER_BIO_LENGTH } from "@/lib/const";
 interface UserProfileProps {
   userProfile: UserProfile;
 }
@@ -30,13 +31,19 @@ const userProfileSchema = z.object({
   name: z
     .string()
     .min(1, { message: "ユーザー名は必須です。" })
-    .max(20, { message: "ユーザー名は7文字以内で入力してください。" }),
+    .max(20, { message: "ユーザー名は20文字以内で入力してください。" }),
   aliasId: z
     .string()
-    .min(1, { message: "表示名は必須です。" })
-    .max(10, { message: "表示名は10文字以内で入力してください。" })
-    .regex(/^[a-zA-Z0-9]+$/, { message: "表示名は英数字で入力してください。" }),
-  bio: z.string().optional(),
+    .min(1, { message: "ユーザーIDは必須です。" })
+    .max(10, { message: "ユーザーIDは10文字以内で入力してください。" })
+    // サーバー側 (updateUser) の検証と一致させる (数字を許すとサーバーで弾かれ原因が伝わらない)
+    .regex(/^[a-zA-Z]+$/, { message: "ユーザーIDは半角英字で入力してください。" }),
+  bio: z
+    .string()
+    .max(MAX_USER_BIO_LENGTH, {
+      message: `自己紹介は${MAX_USER_BIO_LENGTH}文字以内で入力してください。`,
+    })
+    .optional(),
 });
 
 export default function AccountPageContent({ userProfile }: UserProfileProps) {
@@ -47,13 +54,14 @@ export default function AccountPageContent({ userProfile }: UserProfileProps) {
     defaultValues: {
       name: userProfile.name,
       aliasId: userProfile.aliasId,
+      bio: userProfile.bio ?? "",
     },
   });
 
   const handleSubmit = async (formData: z.infer<typeof userProfileSchema>) => {
     try {
       setIsSubmitting(true);
-      await updateUser(formData.name, formData.aliasId);
+      await updateUser(formData.name, formData.aliasId, formData.bio);
 
       success({
         title: "更新しました",
@@ -94,13 +102,7 @@ export default function AccountPageContent({ userProfile }: UserProfileProps) {
                   <FormItem>
                     <FormLabel>名前</FormLabel>
                     <FormControl>
-                      <Input
-                        id="username"
-                        defaultValue={userProfile.name}
-                        value={field.value}
-                        onChange={(e) => field.onChange(e.target.value)}
-                        className="max-w-full"
-                      />
+                      <Input id="username" className="max-w-full" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -116,13 +118,7 @@ export default function AccountPageContent({ userProfile }: UserProfileProps) {
                   <FormItem>
                     <FormLabel>ユーザーID</FormLabel>
                     <FormControl>
-                      <Input
-                        id="displayName"
-                        defaultValue={userProfile.aliasId}
-                        value={field.value}
-                        onChange={(e) => field.onChange(e.target.value)}
-                        className="max-w-full"
-                      />
+                      <Input id="displayName" className="max-w-full" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -140,10 +136,9 @@ export default function AccountPageContent({ userProfile }: UserProfileProps) {
                     <FormControl>
                       <Textarea
                         id="bio"
-                        defaultValue={userProfile.bio}
-                        value={field.value}
-                        onChange={(e) => field.onChange(e.target.value)}
                         className="min-h-[150px] max-w-full"
+                        maxLength={MAX_USER_BIO_LENGTH}
+                        {...field}
                       />
                     </FormControl>
                     <FormMessage />

--- a/src/app/zukan/page.tsx
+++ b/src/app/zukan/page.tsx
@@ -85,7 +85,7 @@ export default async function ZukanPage({
             <Link
               key={plant.id}
               href={`/plants/${plant.id}`}
-              className={`flex items-center gap-4 px-5 py-3.5 hover:bg-gray-50 transition-colors ${
+              className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 sm:flex-nowrap sm:gap-4 sm:px-5 sm:py-3.5 hover:bg-gray-50 transition-colors ${
                 i < plants.length - 1 ? "border-b border-border" : ""
               }`}
               data-testid="zukan-row"
@@ -93,13 +93,14 @@ export default async function ZukanPage({
               <span className="w-10 shrink-0 text-xs text-gray-400 font-medium">
                 No.{String(i + 1).padStart(2, "0")}
               </span>
-              <span className="w-36 shrink-0 flex flex-col gap-0.5 min-w-0">
+              <span className="flex-1 min-w-0 flex flex-col gap-0.5 sm:flex-none sm:w-36">
                 <span className="text-sm font-bold text-gray-900 truncate">{plant.name}</span>
                 {plant.scientific_name && (
                   <span className="text-xs text-gray-400 italic truncate">{plant.scientific_name}</span>
                 )}
               </span>
-              <span className="flex-1 min-w-[60px]">
+              {/* モバイルは「No+名前+匹数 / バー全幅」の2行 (右端の匹数が見切れるのを防ぐ) */}
+              <span className="order-last w-full sm:order-none sm:w-auto sm:flex-1 sm:min-w-[60px]">
                 <CoexistBar value={plant.catCount} max={maxCats} />
               </span>
               <span

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  BookHeart,
+  Camera,
+  Image as ImageIcon,
+  Search,
+  UserRound,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /** ログイン済みユーザーの aliasId (未ログイン時は undefined) */
+  aliasId?: string;
+};
+
+/**
+ * モバイル専用の下部固定タブバー。
+ * sm以上ではヘッダーナビ (HeaderNav) を使うため表示しない。
+ * 中央の「投稿」は未ログインだと middleware が /signin へ誘導する。
+ */
+export default function BottomNav({ aliasId }: Props) {
+  const pathname = usePathname();
+
+  const sideItems = {
+    left: [
+      { href: "/", label: "フィード", icon: ImageIcon, testId: "bottom-nav-feed", isActive: (p: string) => p === "/" },
+      { href: "/zukan", label: "図鑑", icon: BookHeart, testId: "bottom-nav-zukan", isActive: (p: string) => p.startsWith("/zukan") },
+    ],
+    right: [
+      { href: "/plants", label: "さがす", icon: Search, testId: "bottom-nav-search", isActive: (p: string) => p.startsWith("/plants") },
+      aliasId
+        ? { href: `/${aliasId}`, label: "マイページ", icon: UserRound, testId: "bottom-nav-me", isActive: (p: string) => p === `/${aliasId}` }
+        : { href: "/signin", label: "ログイン", icon: UserRound, testId: "bottom-nav-me", isActive: (p: string) => p.startsWith("/signin") },
+    ],
+  };
+
+  const renderItem = (item: (typeof sideItems.left)[number]) => {
+    const active = item.isActive(pathname);
+    return (
+      <Link
+        key={item.href}
+        href={item.href}
+        data-testid={item.testId}
+        className={cn(
+          "flex flex-col items-center justify-center gap-0.5 py-2 min-h-[52px]",
+          active ? "text-green-700" : "text-gray-500",
+        )}
+      >
+        <item.icon className="w-5 h-5" strokeWidth={active ? 2.5 : 2} />
+        <span className={cn("text-[10px] leading-none", active && "font-bold")}>
+          {item.label}
+        </span>
+      </Link>
+    );
+  };
+
+  return (
+    <nav
+      data-testid="bottom-nav"
+      aria-label="メインナビゲーション"
+      className="fixed bottom-0 inset-x-0 z-40 sm:hidden bg-white border-t border-border pb-[env(safe-area-inset-bottom)]"
+    >
+      <div className="grid grid-cols-5">
+        {sideItems.left.map(renderItem)}
+        {/* 中央の投稿ボタン (主要アクションとして浮かせて強調) */}
+        <Link
+          href="/posts/new"
+          data-testid="bottom-nav-post"
+          className="flex flex-col items-center justify-end gap-0.5 py-2 text-gray-500"
+        >
+          <span className="flex items-center justify-center w-12 h-12 -mt-6 rounded-full bg-green-600 text-white shadow-md border-4 border-green-50">
+            <Camera className="w-5 h-5" />
+          </span>
+          <span className="text-[10px] leading-none">投稿</span>
+        </Link>
+        {sideItems.right.map(renderItem)}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,11 +4,12 @@ export default function Footer() {
   return (
     <footer className="bg-primary text-primary-foreground py-6 px-4">
       <div className="max-w-6xl mx-auto text-center">
-        <div className="flex justify-center gap-4 mb-4">
-          <Link href="/contact">お問い合わせ</Link>
-          <Link href="/news">お知らせ</Link>
-          <Link href="/terms">利用規約</Link>
-          <Link href="/privacy">プライバシーポリシー</Link>
+        {/* 語中で折り返さず、項目単位で折り返す */}
+        <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 mb-4">
+          <Link href="/contact" className="whitespace-nowrap">お問い合わせ</Link>
+          <Link href="/news" className="whitespace-nowrap">お知らせ</Link>
+          <Link href="/terms" className="whitespace-nowrap">利用規約</Link>
+          <Link href="/privacy" className="whitespace-nowrap">プライバシーポリシー</Link>
         </div>
         <p className="text-sm text-primary-foreground/60">
           © {new Date().getFullYear()} 猫と植物 neko and plants

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="bg-primary text-primary-foreground py-6 px-4">
+    // max-sm:pb-24: 下部タブバー (BottomNav) にコピーライトが隠れないための余白
+    <footer className="bg-primary text-primary-foreground py-6 px-4 max-sm:pb-24">
       <div className="max-w-6xl mx-auto text-center">
         {/* 語中で折り返さず、項目単位で折り返す */}
         <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 mb-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Button } from "./ui/button";
 import { Camera, Leaf, PawPrint } from "lucide-react";
 import { DropdownMenu } from "./HeaderDropMenu";
 import HeaderNav from "./HeaderNav";
+import BottomNav from "./BottomNav";
 import { createClient } from "@/lib/supabase/server";
 import { getUserProfileByAuthId } from "@/actions/user-action";
 
@@ -16,6 +17,7 @@ export default async function Header() {
   const user = await getUserProfileByAuthId();
 
   return (
+    <>
     <header className="bg-[#2d5a27] text-primary-foreground p-3 px-4">
       <div className="max-w-6xl mx-auto flex items-center gap-1 sm:gap-3">
         <div className="flex items-center gap-1 sm:gap-2 min-w-0">
@@ -43,11 +45,7 @@ export default async function Header() {
             </Button>
           ) : (
             <>
-              <Button variant="outline" className="w-10 h-10 sm:hidden" asChild>
-                <Link href="/posts/new" className="text-accent-foreground">
-                  <Camera className="w-6 h-6 text-green-500" />
-                </Link>
-              </Button>
+              {/* モバイルの投稿導線は下部タブバー (BottomNav) 中央に集約 */}
               <Button variant="outline" className="hidden sm:flex" asChild>
                 <Link href="/posts/new" className="text-accent-foreground">
                   <span className="flex items-center gap-2">
@@ -66,5 +64,8 @@ export default async function Header() {
         </div>
       </div>
     </header>
+    {/* fixed配置なのでDOM上はここでよい (プロフィール取得を重複させないためHeaderから渡す) */}
+    <BottomNav aliasId={session && user ? user.aliasId || undefined : undefined} />
+    </>
   );
 }

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -11,12 +11,12 @@ const NAV_ITEMS = [
   { href: "/plants", label: "さがす", icon: Search, isActive: (path: string) => path.startsWith("/plants") },
 ];
 
-/** ヘッダーのナビゲーション (フィード / 図鑑 / さがす) */
+/** ヘッダーのナビゲーション (フィード / 図鑑 / さがす)。モバイルは BottomNav に移管 */
 export default function HeaderNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex gap-0.5 sm:gap-1 ml-1 sm:ml-2">
+    <nav className="max-sm:hidden flex gap-1 ml-2">
       {NAV_ITEMS.map((item) => (
         <Link
           key={item.href}
@@ -27,7 +27,7 @@ export default function HeaderNav() {
           )}
         >
           <item.icon className="w-4 h-4" />
-          <span className="max-sm:hidden">{item.label}</span>
+          <span>{item.label}</span>
         </Link>
       ))}
     </nav>

--- a/src/components/np/EmptyState.tsx
+++ b/src/components/np/EmptyState.tsx
@@ -3,15 +3,20 @@ import { Image as ImageIcon, Leaf, PawPrint } from "lucide-react";
 type Props = {
   icon?: "leaf" | "image" | "paw";
   text: string;
+  /** 行き止まりにしないための次の導線 (ボタンや補足文) */
+  action?: React.ReactNode;
 };
 
-export default function EmptyState({ icon = "leaf", text }: Props) {
+export default function EmptyState({ icon = "leaf", text, action }: Props) {
   const Icon = icon === "image" ? ImageIcon : icon === "paw" ? PawPrint : Leaf;
 
   return (
     <div className="flex flex-col items-center gap-2 px-4 py-12 text-gray-400">
       <Icon className="w-10 h-10" strokeWidth={1.5} />
       <p className="text-sm">{text}</p>
+      {action && (
+        <div className="mt-2 flex flex-col items-center gap-2">{action}</div>
+      )}
     </div>
   );
 }

--- a/src/components/np/LikeButton.tsx
+++ b/src/components/np/LikeButton.tsx
@@ -80,7 +80,8 @@ export default function LikeButton({ postId, initialLiked, initialCount, size = 
         onClick={onToggle}
         aria-label={liked ? "いいねを取り消す" : "いいねする"}
         className={cn(
-          "transition-colors",
+          // p-2 -m-2: 見た目を変えずにタップ領域を44px相当まで広げる
+          "p-2 -m-2 transition-colors",
           liked ? "text-red-600" : "text-gray-500 hover:text-red-600",
         )}
       >

--- a/src/components/np/PostCard.tsx
+++ b/src/components/np/PostCard.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Images } from "lucide-react";
 import { Post } from "@/types/post";
-import { formatRelativeTime } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import LikeButton from "./LikeButton";
 import PlantTag from "./PlantTag";
@@ -14,6 +14,20 @@ type Props = {
   /** ファーストビューに入るカード (LCP候補) のみ true にする */
   priority?: boolean;
 };
+
+/** 猫チップの列 (2匹まで + 「+N」)。ヘッダー(PC)と本文(モバイル)で共用 */
+function PetChips({ pets, className }: { pets: Post["pets"]; className?: string }) {
+  return (
+    <div className={cn("flex gap-1.5", className)}>
+      {pets.slice(0, 2).map((pet) => (
+        <CatChip key={pet.id} name={pet.name} />
+      ))}
+      {pets.length > 2 && (
+        <span className="text-xs text-gray-500 self-center">+{pets.length - 2}</span>
+      )}
+    </div>
+  );
+}
 
 /** フィード用の投稿カード */
 export default function PostCard({ post, priority = false }: Props) {
@@ -50,14 +64,7 @@ export default function PostCard({ post, priority = false }: Props) {
             <span className="text-xs text-gray-500">{formatRelativeTime(post.createdAt)}</span>
           </div>
           {post.pets.length > 0 && (
-            <div className="flex gap-1.5 max-sm:hidden ml-auto shrink-0">
-              {post.pets.slice(0, 2).map((pet) => (
-                <CatChip key={pet.id} name={pet.name} />
-              ))}
-              {post.pets.length > 2 && (
-                <span className="text-xs text-gray-500 self-center">+{post.pets.length - 2}</span>
-              )}
-            </div>
+            <PetChips pets={post.pets} className="max-sm:hidden ml-auto shrink-0" />
           )}
         </div>
 
@@ -92,12 +99,23 @@ export default function PostCard({ post, priority = false }: Props) {
           {post.comment && (
             <p className="text-sm text-gray-700 leading-normal whitespace-pre-wrap">{post.comment}</p>
           )}
+          {/* モバイルはヘッダー右に余白がないため、猫チップを本文側に出す (猫×植物が中核情報) */}
+          {post.pets.length > 0 && (
+            <PetChips pets={post.pets} className="sm:hidden flex-wrap" />
+          )}
           {post.plants.length > 0 && (
             <div className="flex flex-wrap items-center gap-2">
               {post.plants.map((plant) => (
                 <span key={plant.id} className="inline-flex flex-wrap items-center gap-2">
                   <PlantTag plant={plant} className="pointer-events-auto relative z-10" />
-                  <CoexistBadge catCount={plant.catCount} />
+                  {/* バッジ=共存実績なので、タップは投稿詳細ではなく植物ページへ */}
+                  <Link
+                    href={`/plants/${plant.id}`}
+                    className="pointer-events-auto relative z-10"
+                    aria-label={`${plant.name}の共存実績を見る`}
+                  >
+                    <CoexistBadge catCount={plant.catCount} />
+                  </Link>
                 </span>
               ))}
             </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm md:text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -41,6 +41,9 @@ export const MAX_POST_PETS = 10;
 /** 猫の名前の文字数上限 */
 export const MAX_PET_NAME_LENGTH = 50;
 
+/** ユーザーの自己紹介の最大文字数 */
+export const MAX_USER_BIO_LENGTH = 300;
+
 /** 植物名の文字数上限 */
 export const MAX_PLANT_NAME_LENGTH = 50;
 

--- a/supabase/migrations/20260815085559_add_users_bio.sql
+++ b/supabase/migrations/20260815085559_add_users_bio.sql
@@ -1,0 +1,4 @@
+-- ユーザープロフィールの自己紹介 (任意)。
+-- 文字数上限 (MAX_USER_BIO_LENGTH) はアプリ側 (Server Action) で検証する。
+-- RLS・ポリシー・一意インデックスの変更はないため pgTAP 構造テストの更新は不要。
+alter table public.users add column bio varchar;


### PR DESCRIPTION
## 概要

UIレビューで洗い出した優先度高い改善8件を実装します。モバイル表示崩れ5件のCSS修正、ユーザープロフィールの自己紹介機能追加、/newsクラッシュ対策、/contactフォームフォールバックの5コミット構成です。

## 主な変更

### Phase 1: モバイル表示崩れのCSS修正(#1〜5)
- **図鑑行の「N匹」見切れ** (`src/app/zukan/page.tsx`): モバイルで2行折り返し、PC(sm以上)は現状維持。`flex-wrap`と`gap-x/gap-y`で実装
- **カタログ表ラベル縦割れ** (`src/app/plants/[id]/page.tsx`): 6つの`dt`に`whitespace-nowrap`追加
- **設定タブ折り返し** (`src/app/settings/layout.tsx`): `overflow-x-auto`で横スクロール対応。不正な`<Link><button>`入れ子を`<Link className>`直スタイルに修正
- **フッター折り返し** (`src/components/Footer.tsx`): `flex-wrap`と`gap-x/gap-y`で項目単位の折り返し
- **iOS入力ズーム** (`src/components/ui/input.tsx`): `text-sm`→`text-base md:text-sm`で16px以上を確保

### Phase 2: bio保存対応(#6)
- **DB**: `supabase/migrations/20250815085559_add_users_bio.sql`でusersテーブルにbioカラム追加、`prisma/schema.prisma`を同期
- **定数**: `src/lib/const.ts`に`MAX_USER_BIO_LENGTH = 300`追加
- **Server Action** (`src/actions/user-action.ts`):
  - `getUserProfile`/`getUserProfileByAuthId`に`bio`フィールド追加
  - `updateUser(name, aliasId, bio?)`に拡張。bio未指定時は既存値を保持、空白のみはnull化
  - 300文字上限の検証を追加、`revalidatePath`で公開プロフィールも更新
- **フォーム** (`src/app/settings/profile/AccountPageContent.tsx`):
  - zod: `bio`フィールド追加、`aliasId`の正規表現をサーバ側に合わせ`/^[a-zA-Z]+$/`に修正(数字を許さない)
  - controlled/uncontrolled警告を根治(`{...field}`化)
  - Textareaに`maxLength`属性
- **公開プロフィール** (`src/app/[aliasId]/page.tsx`): bioを表示(改行・単語折り返し対応)
- **テスト** (`src/__test__/actions/user-action.test.ts`): 301字エラー、bio付き正常系、空白のみ→null化を追加

### Phase 3: /newsクラッシュ対策(#7)
- `src/actions/news-action.ts`: `getNews()`のcatchで`throw`→`return []`に変更(console.error維持)。ページの白画面を解消
- `src/app/error.tsx` **新規作成**: グローバルエラーバウンダリ。RSC/Server Actionの予期しない例外をキャッチし、

https://claude.ai/code/session_01SQsACxXRdnWQZXREKBVkaY